### PR TITLE
Add special 500/502/504 classes, with 500 split into 'nginx' and 'trace' pieces.

### DIFF
--- a/musicbrainz/logster/NginxStatus.py
+++ b/musicbrainz/logster/NginxStatus.py
@@ -15,19 +15,23 @@ class Status:
 
 # Status codes are matched here from top to bottom - so do most specific first
 status = [
-    Status('http_503', lambda c: c == 503),
+    Status('http_500_nginx', lambda c, s: c == 500 and s < 1024),
+    Status('http_500_trace', lambda c, s: c == 500 and s > 1024),
+    Status('http_502', lambda c, s: c == 502),
+    Status('http_503', lambda c, s: c == 503),
+    Status('http_504', lambda c, s: c == 504),
 
-    Status('http_1xx', lambda c: c >= 100 and c < 200),
-    Status('http_2xx', lambda c: c >= 200 and c < 300),
-    Status('http_3xx', lambda c: c >= 300 and c < 400),
-    Status('http_4xx', lambda c: c >= 400 and c < 500),
-    Status('http_5xx', lambda c: c >= 500 and c < 600)
+    Status('http_1xx', lambda c, s: c >= 100 and c < 200),
+    Status('http_2xx', lambda c, s: c >= 200 and c < 300),
+    Status('http_3xx', lambda c, s: c >= 300 and c < 400),
+    Status('http_4xx', lambda c, s: c >= 400 and c < 500),
+    Status('http_5xx', lambda c, s: c >= 500 and c < 600)
 ]
 
 class NginxStatus(LogsterParser):
     def __init__(self, option_string=None):
         self.metrics = dict( (s.prop, 0) for s in status)
-        self.reg = re.compile('.*HTTP/1.\d\" (?P<http_status_code>\d{3}) .*')
+        self.reg = re.compile('.*HTTP/1.\d\" (?P<http_status_code>\d{3}) (?P<response_size>\d+) .*')
 
     def parse_line(self, line):
         try:
@@ -36,9 +40,10 @@ class NginxStatus(LogsterParser):
             if regMatch:
                 linebits = regMatch.groupdict()
                 code = int(linebits['http_status_code'])
+                size = int(linebits['response_size'])
 
                 for s in status:
-                    if s.matches(code):
+                    if s.matches(code, size):
                         self.metrics[s.prop] += 1
                         break
             else:

--- a/musicbrainz/logster/NginxStatus.py
+++ b/musicbrainz/logster/NginxStatus.py
@@ -15,7 +15,7 @@ class Status:
 
 # Status codes are matched here from top to bottom - so do most specific first
 status = [
-    Status('http_500_nginx', lambda c, s: c == 500 and s < 1024),
+    Status('http_500_nginx', lambda c, s: c == 500 and s <= 1024),
     Status('http_500_trace', lambda c, s: c == 500 and s > 1024),
     Status('http_502', lambda c, s: c == 502),
     Status('http_503', lambda c, s: c == 503),


### PR DESCRIPTION
This matches the semantics of the tracking done on MBH-309, but will split it up per-server. I've kept http_5xx as a catchall class, though I don't believe we get many, if any, 5xx errors that are not in 50[0234].
